### PR TITLE
!.[]* in type name

### DIFF
--- a/d-mode.el
+++ b/d-mode.el
@@ -441,10 +441,10 @@ Key bindings:
 (font-lock-add-keywords
  'd-mode
  '(("\\<\\(auto\\|immutable\\)\\>" 1 font-lock-keyword-face)
-   ("^[ \t]*\\(?:[_a-zA-Z0-9]+[ \t\n]+\\)*\\([][_a-zA-Z0-9.*!]+\\)[ \t\n]+\\([_a-zA-Z0-9]+\\)[ \t\n]*;"
+   ("^[ \t]*\\(?:[_a-zA-Z0-9]+[ \t\n]+\\)*\\([_a-zA-Z0-9.!]+\\)[][* ]*[ \t\n]+\\([_a-zA-Z0-9]+\\)[ \t\n]*;"
     (1 font-lock-type-face)
     (2 font-lock-variable-name-face))
-   ("^[ \t]*\\(?:[_a-zA-Z0-9]+[ \t\n]+\\)*\\([][_a-zA-Z0-9.*!]+\\)[ \t\n]+\\([_a-zA-Z0-9]+\\)[ \t\n]*("
+   ("^[ \t]*\\(?:[_a-zA-Z0-9]+[ \t\n]+\\)*\\([_a-zA-Z0-9.!]+\\)[][* ]*[ \t\n]+\\([_a-zA-Z0-9]+\\)[ \t\n]*("
     (1 font-lock-type-face)
     (2 font-lock-function-name-face))))
 


### PR DESCRIPTION
I have fixed it so that in declarations like the following

FOO\* or 
FOO[]

the \* and [] will not be fontified in type name face, which is consistent with c++-mode.

This should be okay for the majority of the case. However, it is very difficult to parse all possible types with regexps because technically you can have stuff like these as a function return type or variable type:

TFoo!(char*, int[], TBar!(int))
