### PR TITLE
!.[]* in type names

### DIFF
--- a/d-mode.el
+++ b/d-mode.el
@@ -446,7 +446,8 @@ Key bindings:
     (2 font-lock-variable-name-face))
    ("^[ \t]*\\(?:[_a-zA-Z0-9]+[ \t\n]+\\)*\\([_a-zA-Z0-9.!]+\\)[][* ]*[ \t\n]+\\([_a-zA-Z0-9]+\\)[ \t\n]*("
     (1 font-lock-type-face)
-    (2 font-lock-function-name-face))))
+    (2 font-lock-function-name-face)))
+ t)
 
 
 (provide 'd-mode)


### PR DESCRIPTION
these changes fixes the following cases:

protected:
    int[] foo;

protected:
    int\* foo;

protected:
    FOO.BAR foo;

it also fixes a bug that causes struct/class keywords (when the type has type arguments) being incorrectly fontified in type face.

eg. struct Vec(T, alias N)
