### PR TITLE
Improvements to d-mode

### DIFF
--- a/d-mode.el
+++ b/d-mode.el
@@ -125,13 +125,8 @@
   "List of the tokens made up of characters in the punctuation or
 parenthesis syntax classes that have uses other than as expression
 operators."
-
-;  Emergency Emacs 23 fixes from http://www.prowiki.org/wiki4d/wiki.cgi?EditorSupport/EmacsDMode
-
-;  d (append '("/+" "+/" "..." ".." "!" "*" "&")
-;	    (c-lang-const c-other-op-syntax-tokens)))
-
-  d '("/+" "+/" "..." ".." "!" "*" "&"))
+ d (append '("/+" "+/" "..." ".." "!" "*" "&")
+	    (c-lang-const c-other-op-syntax-tokens)))
 
 (c-lang-defconst c-block-comment-starter d "/*")
 (c-lang-defconst c-block-comment-ender   d "*/")
@@ -197,13 +192,8 @@ operators."
 ;;  d '("with" "version" "extern"))
 
 (c-lang-defconst c-typedef-decl-kwds
-
-;  Emergency Emacs 23 fixes from http://www.prowiki.org/wiki4d/wiki.cgi?EditorSupport/EmacsDMode
-
-;  d (append (c-lang-const c-typedef-decl-kwds)
-;	    '("typedef" "alias")))
-
-   d '("typedef" "alias"))
+ d (append (c-lang-const c-typedef-decl-kwds)
+	    '("typedef" "alias")))
 
 (c-lang-defconst c-decl-hangon-kwds
   d '("export"))


### PR DESCRIPTION
Fixes in these patches:
- Fixed sized array
- Interface inheritance
- More attributes allowed as protection level label
- Fix a potential deadlock in imenu generator
- Fix functions in classes with base class/interface
- Various fixes that make the workaround more robust

I have a question regarding the 2 places where you have the comment "Emergency Emacs 23 fixes" .  On my computer I have to uncomment the block and use that instead of the default code, otherwise my class names will be in variable name face.  I wonder why these blocks are commented out in your original code because they are essential at least for me.

Cheers
