### PR TITLE
Fix backslashes in backquotes

### DIFF
--- a/d-mode.el
+++ b/d-mode.el
@@ -437,7 +437,10 @@ Key bindings:
   (easy-menu-add d-menu)
   (c-run-mode-hooks 'c-mode-common-hook 'd-mode-hook)
   (c-update-modeline)
-  (cc-imenu-init d-imenu-generic-expression))
+  (cc-imenu-init d-imenu-generic-expression)
+  (when (version<= "24.4" emacs-version)
+    (setq-local syntax-propertize-function
+            (syntax-propertize-rules ("`\\(\\\\\\)`" (1 "."))))))
 
 ;; Hideous hacks!
 ;;


### PR DESCRIPTION
This fixes highlighting of raw string literals such as _a single backslash surrounded by backticks_. I'm unsure about the exact  Emacs version where this was made possible.

See also https://stackoverflow.com/questions/25089090/emacs-d-mode-cannot-handle-backquoted-backslashes/25150600?noredirect=1#comment39366860_25150600
