### PR TITLE
Fix keywords list construction to include doc-comment keywords.

### DIFF
--- a/d-mode.el
+++ b/d-mode.el
@@ -308,6 +308,13 @@ operators."
 (defvar d-font-lock-keywords d-font-lock-keywords-3
   "Default expressions to highlight in D mode.")
 
+(defun d-font-lock-keywords-2 ()
+  (c-compose-keywords-list d-font-lock-keywords-2))
+(defun d-font-lock-keywords-3 ()
+  (c-compose-keywords-list d-font-lock-keywords-3))
+(defun d-font-lock-keywords ()
+  (c-compose-keywords-list d-font-lock-keywords))
+
 (defvar d-mode-syntax-table nil
   "Syntax table used in d-mode buffers.")
 (or d-mode-syntax-table


### PR DESCRIPTION
This is the code that is missing for D-mode to enable construction of the keyword list that includes the doc-comment patterns. This is how it is done for all other cc-based modes in cc-fonts.el.
