### PR TITLE
new doc-comment style that recognizes /*!, //!, ///, /++, and /+! prefixes

### DIFF
--- a/d-mode.el
+++ b/d-mode.el
@@ -137,16 +137,29 @@ operators."
 (c-lang-defconst c-literal-start-regexp
   ;; Regexp to match the start of comments and string literals.
   d "/[*+/]\\|\"\\|`")
-;;(c-lang-defconst c-comment-prefix-regexp d "//+\\|\\**")
-
-(c-lang-defconst c-doc-comment-start-regexp
- ;; doc comments for D use "///",  "/**" or doxygen's "/*!" "//!"
- d "/\\*[*!]\\|//[/!]")
 
 (c-lang-defconst c-block-prefix-disallowed-chars
   ;; Allow ':' for inherit list starters.
   d (set-difference (c-lang-const c-block-prefix-disallowed-chars)
-				 '(?:)))
+                    '(?:)))
+
+(defconst doxygen-font-lock-doc-comments
+  (let ((symbol "[a-zA-Z0-9_]+")
+	(header "^ \\* "))
+    `((,(concat header "\\("     symbol "\\):[ \t]*$")
+       1 ,c-doc-markup-face-name prepend nil)
+      (,(concat                  symbol     "()")
+       0 ,c-doc-markup-face-name prepend nil)
+      (,(concat header "\\(" "@" symbol "\\):")
+       1 ,c-doc-markup-face-name prepend nil)
+      (,(concat "[#%@]" symbol)
+       0 ,c-doc-markup-face-name prepend nil))
+    ))
+
+(defconst doxygen-font-lock-keywords
+  `((,(lambda (limit)
+	(c-font-lock-doc-comments "/\\+[+!]\\|/\\*[*!]\\|//[/!]" limit
+	  doxygen-font-lock-doc-comments)))))
 
 ;;----------------------------------------------------------------------------
 

--- a/d-mode.el
+++ b/d-mode.el
@@ -456,7 +456,7 @@ operators."
 (define-derived-mode d-mode d-parent-mode "D"
   "Major mode for editing code written in the D Programming Language.
 
-See http://www.digitalmars.com/d for more information about the D language.
+See http://dlang.org for more information about the D language.
 
 The hook `c-mode-common-hook' is run with no args at mode
 initialization, then `d-mode-hook'.


### PR DESCRIPTION
This adds new doc-comment style that works for D specific comments /+ +/ and "/+!", as well as doxygen style comments "/*!", "//!".  It can be enabled by adding (d-mode . doxygen) to the list of values in the variable c-doc-comment-style.

The second commit is a minor fix of the URL to the D website.