### PR TITLE
(require 'compile)

### DIFF
--- a/d-mode.el
+++ b/d-mode.el
@@ -57,6 +57,10 @@
 
 (require 'cc-mode)
 
+;; Needed to prevent
+;;   "Symbol's value as variable is void: compilation-error-regexp-alist-alist" errors
+(require 'compile)
+
 ;; The set-difference function is used from the Common Lisp extensions.
 (require 'cl)
 


### PR DESCRIPTION
When attempting to go into D-Mode in Emacs 24.3.1 I got this error: "Symbol's value as variable is void: compilation-error-regexp-alist-alist"

Requiring 'compile solves this for me, though I now run into "Symbol's function definition is void: add-function" when I try to indent.  YMMV.