### PR TITLE
This improves the indentation of else version and else debug statements, issue #39

### DIFF
--- a/d-mode.el
+++ b/d-mode.el
@@ -188,7 +188,7 @@ operators."
 ;; Built-in basic types
 (c-lang-defconst c-primitive-type-kwds
   d '("bit" "bool" "byte" "ubyte" "char" "delegate" "double" "float"
-      "function" "int" "long" "ubyte" "short" "uint" "ulong" "ushort"
+      "function" "int" "long" "short" "uint" "ulong" "ushort"
       "cent" "ucent" "real" "ireal" "ifloat" "creal" "cfloat" "cdouble"
       "wchar" "dchar" "void" "string" "wstring" "dstring"))
 

--- a/d-mode.el
+++ b/d-mode.el
@@ -458,11 +458,12 @@ operators."
 ;;;Workaround for special case of 'else static if' not being handled properly
 (defun d-special-case-looking-at (oldfun &rest args)
   (let ((rxp (car args)))
-    (if (and (stringp rxp)
-           (string= rxp "if\\>[^_]"))
-      (or (apply oldfun '("static\\>[^_]"))
-          (apply oldfun args))
-    (apply oldfun args))))
+    (if (and (stringp rxp) (string= rxp "if\\>[^_]"))
+        (or (apply oldfun '("static\\>[^_]"))
+            (apply oldfun '("version\\>[^_]"))
+            (apply oldfun '("debug\\>[^_]"))
+            (apply oldfun args))
+      (apply oldfun args))))
 
 (defadvice c-add-stmt-syntax (around my-c-add-stmt-syntax-wrapper activate)
   (if (not (string= major-mode "d-mode"))


### PR DESCRIPTION
With this change multiple choice version statements like the following are indented correctly

```d
version (A)
{
}
else version (B)
{
}
else
{
}
```

The same works for `debug` statements.
However, if `version` is not on the same line with `else`, the indentation of the trailing `else` is not correct
```d
version (A)
{
}
else
  version (B)
  {
  }
else
{
}
```
Yet, I believe it's still an improvement. Please, review the PR when you have time.
