### PR TITLE
Closes #21.

### DIFF
--- a/d-mode.el
+++ b/d-mode.el
@@ -534,9 +534,13 @@ Key bindings:
   (c-run-mode-hooks 'c-mode-common-hook 'd-mode-hook)
   (c-update-modeline)
   (cc-imenu-init d-imenu-generic-expression)
+  ;; Generate a function that applies D-specific syntax properties.
+  ;; Concretely, inside back-quoted string literals the backslash
+  ;; character '\' is treated as a punctuation symbol.  See help for
+  ;; syntax-propertize-rules function for more information.
   (when (version<= "24.3" emacs-version)
     (setq-local syntax-propertize-function
-            (syntax-propertize-rules ("`\\(\\\\\\)`" (1 "."))))))
+                (syntax-propertize-rules ("`\\([^`]*\\(\\\\\\)[^`]*\\)+`" (2 "."))))))
 
 ;;----------------------------------------------------------------------------
 ;; "Hideous hacks" to support appropriate font-lock behaviour.

--- a/tests/I0021.d
+++ b/tests/I0021.d
@@ -1,0 +1,3 @@
+// #run: (goto-char 74) (c-literal-limits)
+// #out: (72 . 77)
+auto x = `ab\`; // something else


### PR DESCRIPTION
Fix the regexp pattern that matches backslash chars in a back-quoted
string literal.  This pattern is used by the function that applies
mode-specific syntax attributes.

Add a test case that checks the regression.  (The testing infrastructure
will be updated soon to validate the test case.)