### PR TITLE
Allow tests to specify lisp code and expected output.

### DIFF
--- a/tests/I0021.d
+++ b/tests/I0021.d
@@ -1,3 +1,4 @@
-// #run: (goto-char 74) (c-literal-limits)
-// #out: (72 . 77)
-auto x = `ab\`; // something else
+// #run: (let ((a (progn (goto-char 170) (c-literal-limits))) (b (progn (goto-char 230) (c-literal-limits)))) (list a b))
+// #out: ((167 . 172) (227 . 232))
+auto x = `ab\`; // back-quoted string ends with a backslash
+auto y = "c\""; // double-quoted string ends with an escaped "


### PR DESCRIPTION
This is additional work on the testing infrastructure. The test files can now include lisp code to be evaluated on the test buffer and the expected output.  A test fails if the lisp code produces output that doesn't match the expected output.