### PR TITLE
Workaround issue #50.

### DIFF
--- a/d-mode.el
+++ b/d-mode.el
@@ -488,16 +488,8 @@ operators."
         (remove-function (symbol-function 'looking-at)
                          #'d-special-case-looking-at)))))
 
-(if (> emacs-major-version 24)
-    (advice-add 'c-add-stmt-syntax :around #'d-around--c-add-stmt-syntax)
-  (defadvice c-add-stmt-syntax (around d-around--c-add-stmt-syntax activate)
-    (if (not (string= major-mode "d-mode"))
-        ad-do-it
-      (progn
-        (add-function :around (symbol-function 'looking-at) #'d-special-case-looking-at)
-        (unwind-protect
-            ad-do-it
-          (remove-function (symbol-function 'looking-at) #'d-special-case-looking-at))))))
+(when (version<= "24.4" emacs-version)
+  (advice-add 'c-add-stmt-syntax :around #'d-around--c-add-stmt-syntax))
 
 ;;----------------------------------------------------------------------------
 ;;;###autoload (add-to-list 'auto-mode-alist '("\\.d[i]?\\'" . d-mode))


### PR DESCRIPTION
The macros advice-add and add-function were added in Emacs 24.4.
There's no reason to use old style defadvice with add-function.  This
change disables special wrappers that handle indenting of 'static if',
'version' and 'debug' constructs in d-mode for versions of Emacs prior
to version 24.4 because the macros that install the wrappers were not
available until the version 24.4.