### PR TITLE
Correct d-exceptions regexp

### DIFF
--- a/d-mode.el
+++ b/d-mode.el
@@ -202,7 +202,7 @@ operators."
 
 (add-to-list 'compilation-error-regexp-alist-alist
              '(d-exceptions
-               "^[^@]*?@\\(.*?\\)(\\([0-9]+\\)):"
+               "^[a-zA-z0-9\.]*?@\\(.*?\\)(\\([0-9]+\\)):"
                1 2 nil 2))
 (add-to-list 'compilation-error-regexp-alist 'd-exceptions)
 


### PR DESCRIPTION
This corrects the D exception matching regexp to not span multiple lines.