### PR TITLE
fix #49 - Occasional incorrect fontification of string literals due

### DIFF
--- a/d-mode-test.el
+++ b/d-mode-test.el
@@ -308,6 +308,7 @@ is expected to succeed, and nil otherwise."
 (d-test-deftest i0030 "tests/I0030.d" t)
 (d-test-deftest i0035 "tests/I0035.d" (version< "24.4" emacs-version))
 (d-test-deftest i0039 "tests/I0039.d" (version< "24.4" emacs-version))
+(d-test-deftest i0049 "tests/I0049.d" t)
 (d-test-deftest i0064 "tests/I0064.d" t)
 (d-test-deftest i0069 "tests/I0069.txt" t)
 (d-test-deftest i0072 "tests/I0072.txt" t)

--- a/d-mode.el
+++ b/d-mode.el
@@ -7,7 +7,7 @@
 ;; Maintainer:  Russel Winder <russel@winder.org.uk>
 ;;              Vladimir Panteleev <vladimir@thecybershadow.net>
 ;; Created:  March 2007
-;; Version:  201610221417
+;; Version:  201802141931
 ;; Keywords:  D programming language emacs cc-mode
 
 ;;;; NB Version number is date and time yyyymmddhhMM UTC.
@@ -752,7 +752,7 @@ Key bindings:
 	 (zero-or-more
 	  (not (any "`\\"))))
 	(minimal-match
-	 (one-or-more
+	 (zero-or-more
 	  (submatch "\\")
 	  (minimal-match
 	   (zero-or-more

--- a/tests/I0049.d
+++ b/tests/I0049.d
@@ -1,0 +1,8 @@
+// #run: (d-test-fontification)
+
+unittest
+{
+    `beg`;
+    "\"bugbugbug";
+    `end`;
+}

--- a/tests/I0049.d.html
+++ b/tests/I0049.d.html
@@ -1,0 +1,8 @@
+<span class="comment-delimiter">// </span><span class="comment">#run: (d-test-fontification)
+</span>
+<span class="keyword">unittest</span>
+{
+    <span class="string">`beg`</span>;
+    <span class="string">&quot;\&quot;bugbugbug&quot;</span>;
+    <span class="string">`end`</span>;
+}


### PR DESCRIPTION
- the regex that marked backslashes in wysiwyg strings as punctuation
  was trying to only match wysiwyg strings that actually contained a
  backslash
- this could lead to an off-by-one error matching the end of one
  wysiwyg string and the beginning of a suceeding wysiwyg string
  (see https://regex101.com/r/yqdATM/1/)
- fixed by simply matching all wysiwyg strings and optionally marking
  contained backslashes as punctuation

fixes #49