### PR TITLE
Use rx-to-string instead of rx-form

### DIFF
--- a/d-mode.el
+++ b/d-mode.el
@@ -210,7 +210,7 @@ The expression is added to `compilation-error-regexp-alist' and
   (add-to-list
    'compilation-error-regexp-alist-alist
    `(,symbol
-     ,(rx-form
+     ,(rx-to-string
       `(and
 	line-start
 	(group-n 1 (one-or-more any))		; File name


### PR DESCRIPTION
The function `rx-form` is no longer available on Emacs master.