### PR TITLE
Use new cc-mode multiline support for normal strings

### DIFF
--- a/d-mode.el
+++ b/d-mode.el
@@ -162,6 +162,22 @@
   ;; Set to true to indicate that D doesn't mind raw embedded newlines in strings
   d t)
 
+;; Configure cc-mode multiline support (this overrides
+;; c-multiline-string-start-char)
+(c-lang-defconst c-ml-string-opener-re
+  ;; " opens multiline strings in D
+  d "\\(\\(\"\\)\\)")
+
+(c-lang-defconst c-ml-string-max-opener-len
+  d 1)
+
+(c-lang-defconst c-ml-string-any-closer-re
+  ;; Unescaped " closes the string
+  d "\\(?:\\=\\|[^\\]\\)\\(\\(\"\\)\\)")
+
+(c-lang-defconst c-ml-string-max-closer-len
+  d 1)
+
 (c-lang-defconst c-opt-cpp-prefix
   ;; Preprocessor directive recognizer.  D doesn't have cpp, but it has #line
   d "\\s *#\\s *")


### PR DESCRIPTION
`c-multiline-string-start-char` was the previous way to handle multiline strings. cc-mode has replaced this by with `c-ml-string-opener-re` and `c-ml-string-any-closer-re`. This is now used for handling normal strings in D since all normal strings can be multiline.

Fixes #112