### PR TITLE
fix: add `d-forward-decl-or-cast-1` function optional param

### DIFF
--- a/d-mode.el
+++ b/d-mode.el
@@ -531,7 +531,7 @@ Evaluate OLD-FORM if the Emacs version is older than MIN-VERSION,
 
 ;----------------------------------------------------------------------------
 
-(defun d-forward-decl-or-cast-1 (preceding-token-end context last-cast-end)
+(defun d-forward-decl-or-cast-1 (preceding-token-end context last-cast-end &optional inside-macro)
   "D version of `c-forward-decl-or-cast-1'." ;; checkdoc-params: (preceding-token-end context last-cast-end)
   ;; (message "(d-forward-decl-or-cast-1 %S %S %S) @ %S" preceding-token-end context last-cast-end (point))
 


### PR DESCRIPTION
Fix broken (as of Emacs 29) call to `d-forward-decl-or-cast-1` advice function due to apparent change in `c-forward-decl-or-cast-1` function definition specifying an optional `inside-macro` param, which causes most fontification to break. See ['cc-engine.el'](https://github.com/emacs-mirror/emacs/blob/master/lisp/progmodes/cc-engine.el#L10421). More work may be needed to support the optional parameter but for now just get font lock working again.

Tested on Emacs 29; not yet tested on prior versions of Emacs (if anyone could help with that, that would be appreciated). Guidance on how to update unit tests is also welcome, as this is my first contribution.