### PR TITLE
drop call to easy-menu-add

### DIFF
--- a/d-mode.el
+++ b/d-mode.el
@@ -1879,9 +1879,6 @@ Key bindings:
    #'d--syntax-propertize-function)
 
   (c-common-init 'd-mode)
-  (d--if-version>= "28"
-      nil
-    (easy-menu-add d-menu))
   (c-run-mode-hooks 'c-mode-common-hook 'd-mode-hook)
   (c-update-modeline)
   (d--if-version>= "26.0"


### PR DESCRIPTION
Obsolete in GNU Emacs 28.1.