### PR TITLE
update version to 202405290611

### DIFF
--- a/d-mode.el
+++ b/d-mode.el
@@ -7,7 +7,7 @@
 ;; Maintainer:  Russel Winder <russel@winder.org.uk>
 ;;              Vladimir Panteleev <vladimir@thecybershadow.net>
 ;; Created:  March 2007
-;; Version:  202003130913
+;; Version:  202405290611
 ;; Keywords:  D programming language emacs cc-mode
 ;; Package-Requires: ((emacs "25.1"))
 


### PR DESCRIPTION
The version hasn't been updated in four years, blocking NonGNU ELPA from building newer releases with changes such as 9443cea.

The timestamp was taken from commit cbdabb9.