### PR TITLE
Fix imenu with UDAs on Emacs 29.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,7 @@ jobs:
         - 27.2
         - 28.1
         - 28.2
+        - 29.1
         - snapshot
     steps:
     - uses: purcell/setup-emacs@master

--- a/d-mode.el
+++ b/d-mode.el
@@ -1616,8 +1616,9 @@ The expression is added to `compilation-error-regexp-alist' and
 	   (lambda (match-pos inside-macro toplev)
 	     (when toplev
 	       (let* ((got-context
-		       (c-get-fontification-context
-			match-pos nil toplev))
+		       (save-excursion
+			 (c-get-fontification-context
+			  match-pos nil toplev)))
 		      (context (car got-context))
 		      (decl-or-cast
 		       (when (eq context 'top)

--- a/tests/I0124.d
+++ b/tests/I0124.d
@@ -1,0 +1,5 @@
+// #run: (d-test-get-imenu-lines)
+// #out: (5)
+
+@doc("test")
+struct Foo {}


### PR DESCRIPTION
Not sure but this seems to fix tests on Emacs 29.1 in general. Added it to the test matrix as, with this commit, they pass on my machine.